### PR TITLE
Functionality

### DIFF
--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -6,17 +6,6 @@ import Game from '../../Game'
 import { player1, player2 } from '../../players'
 
 function App() {
-  // const player1 = {
-  //   name: 'House Stark',
-  //   id: 'one',
-  //   logo: starkLogo
-  // }
-  // const player2 = {
-  //   name: 'House Lannister',
-  //   id: 'two',
-  //   logo: lannisterLogo
-  // }
-
   const [currentGame, setCurrentGame] = useState(new Game(player1, player2))
   const [p1Wins, setP1Wins] = useState(0)
   const [p2Wins, setP2Wins] = useState(0)

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -3,34 +3,35 @@ import './App.css';
 import Sidebar from '../Sidebar/Sidebar'
 import Grid from '../Grid/Grid'
 import Game from '../../Game'
-import starkLogo from '../../assets/stark-white.png'
-import lannisterLogo from '../../assets/lannister-white.png'
+import { player1, player2 } from '../../players'
 
 function App() {
-  const player1 = {
-    name: 'House Stark',
-    id: 'one',
-    logo: starkLogo
-  }
-  const player2 = {
-    name: 'House Lannister',
-    id: 'two',
-    logo: lannisterLogo
-  }
+  // const player1 = {
+  //   name: 'House Stark',
+  //   id: 'one',
+  //   logo: starkLogo
+  // }
+  // const player2 = {
+  //   name: 'House Lannister',
+  //   id: 'two',
+  //   logo: lannisterLogo
+  // }
+
   const [currentGame, setCurrentGame] = useState(new Game(player1, player2))
   const [p1Wins, setP1Wins] = useState(0)
   const [p2Wins, setP2Wins] = useState(0)
 
-  const displayWins = () => {
+  const updateWins = () => {
       setP1Wins(currentGame.player1.wins)
       setP2Wins(currentGame.player2.wins)
-
 }  
+
+console.log(currentGame)
 
   return (
     <div className="body">
       <Sidebar pl1={true} currentGame={currentGame} p1Wins={p1Wins} />
-      <Grid currentGame={currentGame} displayWins={displayWins} />
+      <Grid currentGame={currentGame} updateWins={updateWins} setCurrentGame={setCurrentGame} />
       <Sidebar currentGame={currentGame} p2Wins={p2Wins} />
     </div>
   );

--- a/src/Components/Grid/Grid.js
+++ b/src/Components/Grid/Grid.js
@@ -6,7 +6,14 @@ import { player1, player2 } from '../../players'
 
 const Grid = ({ currentGame, updateWins, setCurrentGame }) => {
     const [banner, setBanner] = useState(`It is ${currentGame.currentTurn.name}'s Turn`)
-    const [gameTiles, setGameTiles] = useState(currentGame.occupiedTiles)
+    const [occupiedTiles, setOccupiedTiles] = useState(currentGame.occupiedTiles)
+
+    const resetRound = () => {
+      currentGame.resetRound()
+      setOccupiedTiles(currentGame.occupiedTiles)
+      setBanner(`It is ${currentGame.currentTurn.name}'s Turn`)
+      console.log('after reset', currentGame, occupiedTiles)
+    }
     
     const tiles = currentGame.tileIDs.map(id => {
         return <Tile 
@@ -15,19 +22,20 @@ const Grid = ({ currentGame, updateWins, setCurrentGame }) => {
           currentGame={currentGame} 
           setBanner={setBanner}
           updateWins={updateWins}
+          resetRound={resetRound}
+          occupiedTiles={occupiedTiles}
         />
     })
 
-    const declareReset = () => {
+    const declareNewGame = () => {
       setBanner('Winter is Coming')
       setTimeout(resetGame, 3000)
     }
 
     const resetGame = () => {
       setCurrentGame(new Game(player1, player2))
-      currentGame.resetTiles()
       currentGame.togglePlayer()
-      setGameTiles([currentGame.occupiedTiles])
+      setOccupiedTiles([currentGame.occupiedTiles])
       setBanner(`It is ${currentGame.currentTurn.name}'s Turn`)
       updateWins()
     }
@@ -38,7 +46,7 @@ const Grid = ({ currentGame, updateWins, setCurrentGame }) => {
         <h2>{banner}</h2>
         <span className='grid'>
             {tiles}
-            <button onClick={declareReset}>Winter is Coming</button>
+            <button onClick={declareNewGame}>Winter is Coming</button>
         </span>
     </div>
   )

--- a/src/Components/Grid/Grid.js
+++ b/src/Components/Grid/Grid.js
@@ -1,30 +1,35 @@
 import React, { useState} from 'react'
 import './Grid.css'
 import Tile from '../Tile/Tile'
+import Game from '../../Game'
+import { player1, player2 } from '../../players'
 
-const Grid = ({ currentGame, displayWins }) => {
+const Grid = ({ currentGame, updateWins, setCurrentGame }) => {
     const [banner, setBanner] = useState(`It is ${currentGame.currentTurn.name}'s Turn`)
-    const [p1Tiles, setP1Tiles] = useState([currentGame.player1.tiles])
-    const [p2Tiles, setP2Tiles] = useState([currentGame.player2.tiles])
-    //when component renders, it should be looking at each player's tiles array, and asking, for each id within these two arrays, we should render the logo to the corresponding tile
+    const [gameTiles, setGameTiles] = useState(currentGame.occupiedTiles)
     
-    const tiles = currentGame.tiles.map(id => {
+    const tiles = currentGame.tileIDs.map(id => {
         return <Tile 
           key={id} 
           id={id}
           currentGame={currentGame} 
           setBanner={setBanner}
-          displayWins={displayWins}
-          p1Tiles={p1Tiles}
-          p2Tiles={p2Tiles}
+          updateWins={updateWins}
         />
     })
 
+    const declareReset = () => {
+      setBanner('Winter is Coming')
+      setTimeout(resetGame, 3000)
+    }
+
     const resetGame = () => {
+      setCurrentGame(new Game(player1, player2))
       currentGame.resetTiles()
       currentGame.togglePlayer()
+      setGameTiles([currentGame.occupiedTiles])
       setBanner(`It is ${currentGame.currentTurn.name}'s Turn`)
-      displayWins()
+      updateWins()
     }
 
   return (
@@ -33,7 +38,7 @@ const Grid = ({ currentGame, displayWins }) => {
         <h2>{banner}</h2>
         <span className='grid'>
             {tiles}
-            <button onClick={resetGame}>Winter is Coming</button>
+            <button onClick={declareReset}>Winter is Coming</button>
         </span>
     </div>
   )

--- a/src/Components/Grid/Grid.js
+++ b/src/Components/Grid/Grid.js
@@ -4,6 +4,8 @@ import Tile from '../Tile/Tile'
 
 const Grid = ({ currentGame, displayWins }) => {
     const [banner, setBanner] = useState(`It is ${currentGame.currentTurn.name}'s Turn`)
+    const [p1Tiles, setP1Tiles] = useState([currentGame.player1.tiles])
+    const [p2Tiles, setP2Tiles] = useState([currentGame.player2.tiles])
     //when component renders, it should be looking at each player's tiles array, and asking, for each id within these two arrays, we should render the logo to the corresponding tile
     
     const tiles = currentGame.tiles.map(id => {
@@ -13,6 +15,8 @@ const Grid = ({ currentGame, displayWins }) => {
           currentGame={currentGame} 
           setBanner={setBanner}
           displayWins={displayWins}
+          p1Tiles={p1Tiles}
+          p2Tiles={p2Tiles}
         />
     })
 

--- a/src/Components/Sidebar/Sidebar.js
+++ b/src/Components/Sidebar/Sidebar.js
@@ -6,12 +6,21 @@ const SideBar = ({ pl1, currentGame, p1Wins, p2Wins }) => {
     const houseName = pl1 ? currentGame.player1.name : currentGame.player2.name
     const backgroundImage = pl1 ? "player-bar" : "player-bar player-2"
     const wins = p1Wins ? p1Wins : p2Wins
-
+    
+    const checkPlurality = () => {
+        if (p1Wins === 1 || p2Wins === 1) {
+            return "Reign"
+        } else {
+            return "Reigns"
+        }
+    }
+    
+    const pluralReigns = checkPlurality()
     return (
         <div className={backgroundImage}>
             <h2>{houseName}</h2>
             <img src={dynamicIcon} className="icon"></img>
-            <h3>{wins} Reigns</h3>
+            <h3>{wins} {pluralReigns}</h3>
         </div>
     )
 }

--- a/src/Components/Tile/Tile.js
+++ b/src/Components/Tile/Tile.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import './Tile.css'
 
-const Tile = ({ id, currentGame, setBanner, displayWins }) => {
+const Tile = ({ id, currentGame, setBanner, displayWins, p1Tiles, p2Tiles }) => {
     const [playerLogo, setPlayerLogo] = useState()
     const [open, setOpen] = useState(true)
 

--- a/src/Components/Tile/Tile.js
+++ b/src/Components/Tile/Tile.js
@@ -1,22 +1,31 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import './Tile.css'
 
-const Tile = ({ id, currentGame, setBanner, updateWins }) => {
+const Tile = ({ id, currentGame, setBanner, updateWins, resetRound, occupiedTiles }) => {
     const [playerLogo, setPlayerLogo] = useState()
-    const [available, setAvailable] = useState(true)
-
-    useEffect(() => {
-        determineLogo(id)
-    }, [])
     
-    const determineLogo = (id) => {
-        if (currentGame.player1.tiles.includes(id)) {
+    const placeLogo = () => {
+        if (currentGame.currentTurn === currentGame.player1) {
             setPlayerLogo(<img src={currentGame.player1.logo} className='tile-icon' />)
-        } else if (currentGame.player2.tiles.includes(id)) {
-            setPlayerLogo(<img src={currentGame.player2.logo} className='tile-icon' />)
         } else {
-            setPlayerLogo(null)
-        }
+            setPlayerLogo(<img src={currentGame.player2.logo} className='tile-icon' />)
+        } 
+    }
+
+    const changeTurn = () => {
+        currentGame.togglePlayer()
+        setBanner(`It is ${currentGame.currentTurn.name}'s Turn`)
+    }
+
+    const resetLogo = () => {
+        setPlayerLogo()
+    }
+
+    const declareWin = () => {
+        setBanner(`${currentGame.currentTurn.name} sits upon the Iron Throne`)
+        updateWins()
+        setTimeout(resetRound, 3000)
+        setTimeout(resetLogo, 3000)
     }
         
     const claimTile = (id) => {
@@ -24,13 +33,11 @@ const Tile = ({ id, currentGame, setBanner, updateWins }) => {
         const win = currentGame.checkWinConditions()
         
         if (available && !win) {
-            setAvailable(false)
-            determineLogo(id)
-            currentGame.togglePlayer()
-            setBanner(`It is ${currentGame.currentTurn.name}'s Turn`)
+            placeLogo()
+            changeTurn()
         } else if ( available && win) {
-            setBanner(`${currentGame.currentTurn.name} sits upon the Iron Throne`)
-            updateWins()
+            placeLogo()
+            declareWin()
         } 
     }
     
@@ -40,8 +47,7 @@ const Tile = ({ id, currentGame, setBanner, updateWins }) => {
             className="tile"    
             id={id}
             onClick={(e) => {
-                if (available) {
-                claimTile(e.target.id)}}}
+                claimTile(e.target.id)}}
             >
                 {playerLogo}
             </article>

--- a/src/Components/Tile/Tile.js
+++ b/src/Components/Tile/Tile.js
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react'
 import './Tile.css'
 
-const Tile = ({ id, currentGame, setBanner, displayWins, p1Tiles, p2Tiles }) => {
+const Tile = ({ id, currentGame, setBanner, updateWins }) => {
     const [playerLogo, setPlayerLogo] = useState()
-    const [open, setOpen] = useState(true)
+    const [available, setAvailable] = useState(true)
 
     useEffect(() => {
         determineLogo(id)
@@ -24,13 +24,13 @@ const Tile = ({ id, currentGame, setBanner, displayWins, p1Tiles, p2Tiles }) => 
         const win = currentGame.checkWinConditions()
         
         if (available && !win) {
-            setOpen(false)
+            setAvailable(false)
             determineLogo(id)
             currentGame.togglePlayer()
             setBanner(`It is ${currentGame.currentTurn.name}'s Turn`)
         } else if ( available && win) {
             setBanner(`${currentGame.currentTurn.name} sits upon the Iron Throne`)
-            displayWins()
+            updateWins()
         } 
     }
     
@@ -40,7 +40,7 @@ const Tile = ({ id, currentGame, setBanner, displayWins, p1Tiles, p2Tiles }) => 
             className="tile"    
             id={id}
             onClick={(e) => {
-                if (open) {
+                if (available) {
                 claimTile(e.target.id)}}}
             >
                 {playerLogo}

--- a/src/Game.js
+++ b/src/Game.js
@@ -35,11 +35,9 @@ class Game {
     }
 
     verifyTile = (selection) => {
-        console.log(this.occupiedTiles)
         if (!this.occupiedTiles.includes(selection)) {
             this.occupiedTiles.push(selection)
             this.currentTurn.tiles.push(selection)
-            console.log(this.occupiedTiles)
             return true
         }
     }

--- a/src/Game.js
+++ b/src/Game.js
@@ -5,7 +5,7 @@ class Game {
         this.player2 = new Player(player2);
         this.currentTurn = this.player1;
         this.tileIDs = [1, 2, 3, 4, 5, 6, 7, 8, 9]
-        this.occupiedTiles = [null];
+        this.occupiedTiles = [];
         this.winningConditions = [
             ['1', '2', '3'],
             ['4', '5', '6'],
@@ -18,14 +18,17 @@ class Game {
         ]
     }
 
-    resetTiles = () => {
-        this.occupiedTiles = [null]
+    resetRound = () => {
         this.player1.tiles = []
         this.player2.tiles = []
-        this.player1.wins = 0
-        this.player2.wins = 0
+        this.concatOccupiedTiles()
+        this.togglePlayer()
     }
 
+    concatOccupiedTiles = () => {
+        this.occupiedTiles = this.player1.tiles.concat(this.player2.tiles)
+    }
+    
     togglePlayer = () => {
         if (this.currentTurn.id === this.player1.id) {
         this.currentTurn = this.player2
@@ -35,11 +38,17 @@ class Game {
     }
 
     verifyTile = (selection) => {
-        if (!this.occupiedTiles.includes(selection)) {
-            this.occupiedTiles.push(selection)
-            this.currentTurn.tiles.push(selection)
+        if (!this.occupiedTiles.includes(selection) && selection != '') {
+            this.addTile(selection)
             return true
+        } else {
+            return false
         }
+    }
+    
+    addTile = (selection) => {
+        this.currentTurn.tiles.push(selection)
+        this.concatOccupiedTiles()
     }
 
     checkWinConditions = () => {
@@ -60,12 +69,6 @@ class Game {
           }
         }
     }
-
-    resetWinCount() {
-        this.player1.wins = 0;
-        this.player2.wins = 0;
-    }
-
 }
 
 export default Game

--- a/src/Game.js
+++ b/src/Game.js
@@ -4,7 +4,7 @@ class Game {
         this.player1 = new Player(player1);
         this.player2 = new Player(player2);
         this.currentTurn = this.player1;
-        this.tiles = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        this.tileIDs = [1, 2, 3, 4, 5, 6, 7, 8, 9]
         this.occupiedTiles = [null];
         this.winningConditions = [
             ['1', '2', '3'],

--- a/src/Player.js
+++ b/src/Player.js
@@ -2,7 +2,7 @@ class Player {
     constructor(player) {
         this.name = player.name;
         this.id = player.id;
-        this.wins = player.wins || 0;
+        this.wins = 0;
         this.logo = player.logo;
         this.tiles = []
     }

--- a/src/players.js
+++ b/src/players.js
@@ -1,0 +1,14 @@
+import starkLogo from './assets/stark-white.png'
+import lannisterLogo from './assets/lannister-white.png'
+
+export const player1 = {
+    name: 'House Stark',
+    id: 'one',
+    logo: starkLogo
+  }
+
+export const player2 = {
+    name: 'House Lannister',
+    id: 'two',
+    logo: lannisterLogo
+  }


### PR DESCRIPTION
Break down functions to better align with SRP 
add plurarlity to sidebar win counts
instantiate new game on button press
concat occupied tiles from individual player tiles
currently, on round reset after win, only last tile selected will reset (because that is where the win function was invoked from)
- attempted to move all tile logo states to Grid component, but it didn't work. I think that is going to have to be what I do, but not sure how to structure it so that the state of each tile lives in grid and can be reset from there